### PR TITLE
17 legacy nvidia fix zip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 RUN apt-get update
 RUN apt-get install curl wget -y
 
 # Install a specific version of docker
-RUN curl -sSL https://get.docker.com/ | sed 's/docker-ce/docker-ce=18.03.0~ce-0~ubuntu/' | sh
+RUN curl -sSL https://get.docker.com/ | sh
 
 # nvidia-docker jazz
 RUN curl -s -L https://nvidia.github.io/nvidia-docker/gpgkey | \

--- a/worker.py
+++ b/worker.py
@@ -24,7 +24,7 @@ import yaml
 from os.path import join, exists
 from glob import glob
 from subprocess import Popen, call, check_output, CalledProcessError, PIPE
-from zipfile import ZipFile, BadZipfile
+from zipfile import ZipFile, BadZipfile, ZIP_DEFLATED
 
 from billiard import SoftTimeLimitExceeded
 from celery import Celery, task

--- a/worker.py
+++ b/worker.py
@@ -344,6 +344,7 @@ def run(task_id, task_args):
         run_dir = join(root_dir, 'run')
         shared_dir = tempfile.mkdtemp(dir=temp_dir)
         hidden_ref_dir = ''
+        data_dir = '/data'
 
         # Fetch and stage the bundles
         logger.info("Fetching bundles...")
@@ -553,6 +554,7 @@ def run(task_id, task_args):
                     # Set the right volume
                     '-v', '{0}:{0}'.format(run_dir),
                     '-v', '{0}:{0}'.format(shared_dir),
+                    '-v', '{0}:/data:ro'.format(data_dir),
                     # Set aside 512m memory for the host
                     '--memory', '{}MB'.format(available_memory_mib - 512),
                     # Don't buffer python output, so we don't lose any
@@ -631,6 +633,7 @@ def run(task_id, task_args):
                     # Set the right volume
                     '-v', '{0}:{0}'.format(run_dir),
                     '-v', '{0}:{0}'.format(shared_dir),
+                    '-v', '{0}:/data:ro'.format(data_dir),
                     # Set aside 512m memory for the host
                     '--memory', '{}MB'.format(available_memory_mib - 512),
                     # Add the participants submission dir to PYTHONPATH


### PR DESCRIPTION
* Fix the upload of large zip `LargeZipFile: Central directory offset would require ZIP64 extensions`.

* Add the possibility to access the `/data` folder of the compute worker from inside the docker.