### PR TITLE
celeryconfig.py: parse a bool from BROKER_USE_SSL environment variable.

### DIFF
--- a/celeryconfig.py
+++ b/celeryconfig.py
@@ -1,8 +1,26 @@
 import os
 
 
+# One always get a string from env and need to convert to bool.
+def get_bool_from_env(key, default):
+    try:
+        val = os.environ[key]
+    except KeyError:
+        return default
+    else:
+        if val == "True":
+            return True
+        elif val == "False":
+            return False
+        else:
+            raise ValueError(
+                "'%s' value should be string 'False' or 'True' (was '%s')"
+                % (key, val)
+            )
+
+
 BROKER_URL = os.environ.get('BROKER_URL')
-BROKER_USE_SSL = os.environ.get('BROKER_USE_SSL', False)
+BROKER_USE_SSL = get_bool_from_env('BROKER_USE_SSL', False)
 CELERY_IMPORTS = ('worker',)
 CELERY_TASK_SERIALIZER = 'json'
 CELERY_ACCEPT_CONTENT = ('json',)


### PR DESCRIPTION
BROKER_USE_SSL is read from the environ and if it exists it will be a
string and unless it is an empty string it will always eval true.  So
parse it properly.

---

To replicate the issue just try to set it to "False" in the env and see that it always to fail to connect, because the string "False" always evals true. The only way to use the `BROKER_USE_SSL` environment variable to disable ssl, is to set it to the empty string which I don't think was the intension (and so this patch does not support).