### PR TITLE
raise Exception when network error occured

### DIFF
--- a/worker.py
+++ b/worker.py
@@ -126,8 +126,11 @@ def get_bundle(root_dir, relative_dir, url):
         try:
             urllib.urlretrieve(url, bundle_file.name)
             break
-        except:
+        except Exception as e:
             retries += 1
+            # try and fail 3 times, can be network error
+            if retries >= 3:
+                raise e
 
     # Extracting files or grabbing extras
     bundle_path = join(root_dir, relative_dir)


### PR DESCRIPTION
 issue : https://github.com/codalab/codalab-competitions/issues/2814#issuecomment-975017980  , you can get the reason why urllib.urlretrieve(url, bundle_file.name) can't download file. If not , NoneType Error appears sometimes.